### PR TITLE
Rename

### DIFF
--- a/paypro-old.gemspec
+++ b/paypro-old.gemspec
@@ -3,7 +3,7 @@
 require File.expand_path('lib/paypro/version', __dir__)
 
 Gem::Specification.new do |s|
-  s.name = 'paypro'
+  s.name = 'paypro-old'
   s.version = PayPro::VERSION
   s.license = 'MIT'
   s.homepage = 'https://github.com/paypronl/paypro-ruby-v1'


### PR DESCRIPTION
Rename `paypro` to `paypro-old` so we can use the new `paypro` gem which has a different source